### PR TITLE
Enable schedule triggers by default and fix E2E webhook port

### DIFF
--- a/app/actions/supabase/repositories/get-trigger-settings.ts
+++ b/app/actions/supabase/repositories/get-trigger-settings.ts
@@ -26,7 +26,7 @@ export async function getTriggerSettings(
       triggerOnCommit: false,
       triggerOnPrChange: true,
       triggerOnMerged: false,
-      triggerOnSchedule: false,
+      triggerOnSchedule: true,
       scheduleTimeLocal: "09:00",
       scheduleTimeUTC: "",
       scheduleIncludeWeekends: false,

--- a/app/settings/triggers/page.tsx
+++ b/app/settings/triggers/page.tsx
@@ -71,7 +71,21 @@ export default function TriggersPage() {
         settings.scheduleTimeLocal = "09:00";
       }
 
-      setTriggerSettings(settings);
+      // If this is a first-time user (no UTC time calculated yet) and schedule is enabled,
+      // automatically calculate UTC and save the settings
+      if (!settings.scheduleTimeUTC && settings.triggerOnSchedule && settings.scheduleTimeLocal) {
+        const calculatedUTC = convertLocalToUTC(settings.scheduleTimeLocal);
+        const updatedSettings = {
+          ...settings,
+          scheduleTimeUTC: calculatedUTC,
+        };
+        
+        // Auto-save the default settings with calculated UTC
+        await saveSettings(updatedSettings);
+        setTriggerSettings(updatedSettings);
+      } else {
+        setTriggerSettings(settings);
+      }
     } catch (error) {
       console.error("Failed to fetch trigger settings:", error);
     } finally {

--- a/e2e/setup/stripe.setup.ts
+++ b/e2e/setup/stripe.setup.ts
@@ -43,7 +43,7 @@ async function globalSetup() {
       "--events",
       "payment_intent.succeeded",
       "--forward-to",
-      "localhost:4000/api/stripe/webhook",
+      "localhost:4001/api/stripe/webhook",
       "--api-key",
       apiKey,
     ],


### PR DESCRIPTION
- Set triggerOnSchedule default to true for first-time users
- Auto-calculate and save UTC time on first visit to trigger page
- Fix Stripe webhook forwarding from port 4000 to 4001 in E2E tests
- Ensures new users have working schedule triggers at 9am local time
- Resolves auto-reload E2E test failures caused by webhook port mismatch