### PR TITLE
Fix usage statistics to filter by selected repository

### DIFF
--- a/app/api/supabase/get-usage-stats/route.ts
+++ b/app/api/supabase/get-usage-stats/route.ts
@@ -5,10 +5,12 @@ import { supabaseAdmin } from "@/lib/supabase/server";
 
 export async function POST(request: Request) {
   try {
-    const { ownerName, userId, periodStart, periodEnd } = await request.json();
-    console.log({ ownerName, userId, periodStart, periodEnd });
+    const { ownerName, repoName, userId, periodStart, periodEnd } = await request.json();
+    console.log({ ownerName, repoName, userId, periodStart, periodEnd });
 
     if (!ownerName) return NextResponse.json({ error: "Owner name is required" }, { status: 400 });
+    if (!repoName)
+      return NextResponse.json({ error: "Repository name is required" }, { status: 400 });
     if (!userId) return NextResponse.json({ error: "User ID is required" }, { status: 400 });
     if (!periodStart || !periodEnd)
       return NextResponse.json({ error: "Period is required" }, { status: 400 });
@@ -17,7 +19,8 @@ export async function POST(request: Request) {
     const { data: allTimeData, error: allTimeError } = await supabaseAdmin
       .from("usage_with_issues")
       .select("*")
-      .eq("owner_name", ownerName);
+      .eq("owner_name", ownerName)
+      .eq("repo_name", repoName);
 
     if (allTimeError)
       return NextResponse.json({ error: "Failed to fetch all-time data" }, { status: 500 });
@@ -29,6 +32,7 @@ export async function POST(request: Request) {
       .from("usage_with_issues")
       .select("*")
       .eq("owner_name", ownerName)
+      .eq("repo_name", repoName)
       .gte("created_at", periodStart)
       .lte("created_at", periodEnd);
 

--- a/app/dashboard/usage/page.tsx
+++ b/app/dashboard/usage/page.tsx
@@ -17,13 +17,14 @@ import { fetchWithTiming } from "@/utils/fetch";
 export default function UsagePage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const { userId, currentOwnerName, currentStripeCustomerId } = useAccountContext();
+  const { userId, currentOwnerName, currentRepoName, currentStripeCustomerId } =
+    useAccountContext();
   const [usageStats, setUsageStats] = useState<UsageStats | null>(null);
   const [isPortalLoading, setIsPortalLoading] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
-      if (!currentStripeCustomerId) {
+      if (!currentStripeCustomerId || !currentRepoName) {
         setIsLoading(false);
         return;
       }
@@ -43,6 +44,7 @@ export default function UsagePage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             ownerName: currentOwnerName,
+            repoName: currentRepoName,
             userId: userId,
             periodStart: thisMonthStart,
             periodEnd: nextMonthStart,
@@ -59,7 +61,7 @@ export default function UsagePage() {
     };
 
     fetchData();
-  }, [currentStripeCustomerId, currentOwnerName, userId]);
+  }, [currentStripeCustomerId, currentOwnerName, currentRepoName, userId]);
 
   const formatNumber = (value?: number) => {
     if (!value) return "-";


### PR DESCRIPTION
Previously, usage stats showed aggregated data across all repositories for an owner, even when a specific repository was selected. Now the stats correctly filter by the selected repository when provided.

Changes:
- Made repoName mandatory in get-usage-stats API endpoint
- Updated usage page to pass selected repository to API
- Added repository filtering to database queries
- Updated useEffect dependencies to refetch when repo changes

🤖 Generated with [Claude Code](https://claude.ai/code)