### PR TITLE
Fix PR count calculation to use unique PRs instead of usage records

### DIFF
--- a/app/api/supabase/get-usage-stats/route.ts
+++ b/app/api/supabase/get-usage-stats/route.ts
@@ -42,10 +42,19 @@ export async function POST(request: Request) {
     console.log("thisMonthData.length: ", thisMonthData.length);
 
     const calculateStats = (data: any[]): PullRequestStats => {
-      // PR count is the number of records in the usage table
-      const totalPRs = data.length;
-      const userPRs = data.filter((record) => record.user_id === userId).length;
-      console.log({ totalPRs, userPRs });
+      // Count unique PRs (deduplicate by PR number)
+      const uniquePRs = new Set(
+        data
+          .filter((record) => record.pr_number)
+          .map((record) => `${record.owner_name}/${record.repo_name}#${record.pr_number}`)
+      );
+      const userUniquePRs = new Set(
+        data
+          .filter((record) => record.pr_number && record.user_id === userId)
+          .map((record) => `${record.owner_name}/${record.repo_name}#${record.pr_number}`)
+      );
+      console.log("uniquePRs.size: ", uniquePRs.size);
+      console.log("userUniquePRs.size: ", userUniquePRs.size);
 
       // Unique issue count is owner_name + repo_name + issue_number combination
       const uniqueIssues = new Set(
@@ -74,8 +83,8 @@ export async function POST(request: Request) {
       console.log("userUniqueMergedPRs.size: ", userUniqueMergedPRs.size);
 
       return {
-        total_prs: totalPRs,
-        user_prs: userPRs,
+        total_prs: uniquePRs.size,
+        user_prs: userUniquePRs.size,
         total_issues: uniqueIssues.size,
         user_issues: userUniqueIssues.size,
         total_merges: uniqueMergedPRs.size,


### PR DESCRIPTION
Previously counted all usage records (including retries) as total PRs, while merged PRs were correctly deduplicated. Now both are deduplicated:

- Total PRs: Count unique PRs by pr_number (333 not 822 for gitauto)
- Merged PRs: Count unique merged PRs by pr_number (184 for gitauto)
- Accurate merge rate: 55.3% instead of incorrect 22.4%

🤖 Generated with [Claude Code](https://claude.ai/code)