### PR TITLE
Update pricing from $2 to $3 per PR globally

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ This is a Next.js 15 application using App Router for GitAuto - a SaaS platform 
 
 - **Dual system in operation**: Both subscription-based (legacy) and credit-based (new) payment systems are active
 - **Legacy customers**: Existing paying customers still have monthly/yearly Stripe subscriptions
-- **New system**: New customers use credit-based system ($2 per PR, auto-reload, etc.)
+- **New system**: New customers use credit-based system ($3 per PR, auto-reload, etc.)
 - **Do not remove subscription code**: Billing period and subscription functionality must be maintained for existing customers
 
 ### Database Design Rules

--- a/app/blog/posts/2025-01-28-how-to-open-pull-requests-from-github-issues.mdx
+++ b/app/blog/posts/2025-01-28-how-to-open-pull-requests-from-github-issues.mdx
@@ -166,16 +166,16 @@ And here's the result - a properly spaced heading with an added blank line:
 
 As of writing, GitAuto offers several pricing tiers:
 
-- Free Plan: $10 free credits (~5 PRs)
-- Standard Plan: $2 per PR with $10 minimum purchase  
+- Free Plan: $10 free credits (~3 PRs)
+- Standard Plan: $3 per PR with $10 minimum purchase  
 - Enterprise Plan: Custom pricing with advanced features
 
 Important notes about credit usage:
 
-- Each PR costs $2 in credits
+- Each PR costs $3 in credits
 - Multiple iterations on the same PR count as one PR
 - This includes both reassignments from the issue and review comments on the PR
-- When bulk assigning issues, each resulting PR counts separately (e.g., assigning 10 issues that each create PRs consumes $20 in credits)
+- When bulk assigning issues, each resulting PR counts separately (e.g., assigning 10 issues that each create PRs consumes $30 in credits)
 
 You can check your remaining issue count by creating a new issue (e.g., creating a test issue).
 

--- a/app/blog/posts/2025-08-08-best-unit-test-agents-2025.mdx
+++ b/app/blog/posts/2025-08-08-best-unit-test-agents-2025.mdx
@@ -104,7 +104,7 @@ AI-powered unit test generation has revolutionized how development teams approac
 
 **Languages:** Language-agnostic (works with any language and testing framework)
 
-**Pricing:** Free ($10 credits ~5 PRs), Standard ($2/PR, min $10), Enterprise (custom pricing)
+**Pricing:** Free ($10 credits ~3 PRs), Standard ($3/PR, min $10), Enterprise (custom pricing)
 
 ## 6. Keploy: Open-Source eBPF-Based Testing
 

--- a/app/dashboard/credits/jsonld.ts
+++ b/app/dashboard/credits/jsonld.ts
@@ -54,10 +54,10 @@ export const creditsJsonLd = {
     "@type": "Offer",
     priceSpecification: {
       "@type": "PriceSpecification",
-      price: "2",
+      price: "3",
       priceCurrency: "USD",
       unitText: "per PR",
-      description: "Pay-as-you-go pricing at $2 per pull request generated",
+      description: "Pay-as-you-go pricing at $3 per pull request generated",
       minPrice: "10",
       eligibleQuantity: {
         "@type": "QuantitativeValue",

--- a/config/pricing.ts
+++ b/config/pricing.ts
@@ -11,7 +11,7 @@ export const TEST_LEGACY_CUSTOMER_ID = "cus_QO4R5vh6FJuN7t";
 
 export const CREDIT_PRICING = {
   PER_PR: {
-    AMOUNT_USD: 2,
+    AMOUNT_USD: 3,
   },
   PURCHASE_LIMITS: {
     MIN_AMOUNT_USD: 10,
@@ -28,7 +28,9 @@ export const CREDIT_PRICING = {
 };
 
 export const FREE_CREDITS_AMOUNT_USD = 10;
-export const FREE_PRS_LIMIT = Math.floor(FREE_CREDITS_AMOUNT_USD / CREDIT_PRICING.PER_PR.AMOUNT_USD);
+export const FREE_PRS_LIMIT = Math.floor(
+  FREE_CREDITS_AMOUNT_USD / CREDIT_PRICING.PER_PR.AMOUNT_USD
+);
 
 export const FREE_FEATURES = [
   ANTHROPIC_MODEL_CLAUDE_40,

--- a/e2e/credit-workflow/legacy-customers.spec.ts
+++ b/e2e/credit-workflow/legacy-customers.spec.ts
@@ -236,7 +236,7 @@ test.describe("Credits - Legacy subscription owners", () => {
     await page.goto("/dashboard/credits");
 
     // Should show credit pricing information
-    await expect(page.locator("text=$2")).toBeVisible();
+    await expect(page.locator("text=$3")).toBeVisible();
     await expect(page.locator("text=per PR")).toBeVisible();
     await expect(page.locator("text=Credits expire after 1 year")).toBeVisible();
   });

--- a/e2e/credit-workflow/non-signed-users.spec.ts
+++ b/e2e/credit-workflow/non-signed-users.spec.ts
@@ -22,7 +22,7 @@ test.describe("Credits - Non-signed in users", () => {
     await page.goto("/pricing");
 
     // Should see credit pricing information
-    await expect(page.getByText("$2").first()).toBeVisible();
+    await expect(page.getByText("$3").first()).toBeVisible();
     await expect(page.getByText("per PR").first()).toBeVisible();
 
     // Buy Credits button should show modal when clicked


### PR DESCRIPTION
- Update core pricing configuration from $2 to $3 per PR
- Update JSON-LD schema pricing and descriptions
- Update E2E test expectations for new pricing
- Update blog posts with new pricing and calculations
- Update documentation references
- Free credits now provide ~3 PRs instead of ~5 PRs ($10 / $3 = 3)

🤖 Generated with [Claude Code](https://claude.ai/code)